### PR TITLE
Replace text highlighter

### DIFF
--- a/STGB_Test/STGB_Test/HelperFunctions.swift
+++ b/STGB_Test/STGB_Test/HelperFunctions.swift
@@ -10,39 +10,59 @@ import SwiftUI
 import Foundation
 import Combine
 
-
-
 struct HighlightedText: View {
-let text: String
-let searchTerm: String
-let caseInsensitiv: Bool
+    let text: String
+    let searchTerm: String
+    let caseInsensitiv: Bool
 
-init(_ text: String, searchTerm: String, caseInsensitiv: Bool = true) {
-    self.text = text
-    self.searchTerm = searchTerm
-    self.caseInsensitiv = caseInsensitiv
-}
-
-var body: some View {
-    guard  let regex = try? NSRegularExpression(pattern: NSRegularExpression.escapedPattern(for: searchTerm).trimmingCharacters(in: .whitespacesAndNewlines).folding(options: .regularExpression, locale: .current), options: caseInsensitiv ? .caseInsensitive : .init()) else {
-        return Text(text)
+    init(_ text: String, searchTerm: String, caseInsensitiv: Bool = true) {
+        self.text = text
+        self.searchTerm = searchTerm
+        self.caseInsensitiv = caseInsensitiv
     }
-   let range = NSRange(location: 0, length: text.count)
-            let matches = regex.matches(in: text, options: .withTransparentBounds, range: range)
 
-            return text.enumerated().map { (char) -> Text in
-                guard matches.filter( {
-                    $0.range.contains(char.offset)
-                }).count == 0 else {
-                    return Text( String(char.element) ).foregroundColor(.yellow).fontWeight(.bold)
-                }
-                return Text( String(char.element) )
-
-            }.reduce(Text("")) { (a, b) -> Text in
-                return a + b
-            }
+    var body: some View {
+        // ignore empty strings
+        guard !text.isEmpty && !searchTerm.isEmpty else { return Text(text) }
+        // split: e.g. "Tötung" by "ötu" -> ["T", "ötu", "ng"]
+        let parts = text.split(usingRegex: searchTerm, caseInsensitive: caseInsensitiv)
+        // reduce all parts into a single text
+        return parts.reduce(Text("")) { partialResult, part in
+            // ignore if part is not the searched term.
+            guard part.lowercased() == searchTerm.lowercased() else { return partialResult + Text(part) }
+            // Only the searched items arrive here. Colorize it.
+            return partialResult + Text(part).foregroundColor(.yellow).bold()
         }
     }
+}
+
+extension String {
+    /// Splits self into an array of strings.
+    /// Compared to `components(separatedBy:)`, this function still contains the pattern at the correct index.
+    /// Splitting "ABC" by "B", returns an array like ["A", "B", "C"].
+    ///
+    /// - Parameters:
+    ///   - pattern: The search term.
+    ///   - caseInsensitive: A boolean value indicating if case sensitivity matters.
+    ///
+    /// - Returns: an array of strings.
+    func split(usingRegex pattern: String, caseInsensitive: Bool = false) -> [String] {
+        let origin = caseInsensitive ? self.lowercased() : self
+        let regexPattern = caseInsensitive ? pattern.lowercased() : pattern
+
+        guard let regex = try? NSRegularExpression(pattern: regexPattern) else { return [] }
+
+        let matches = regex.matches(in: origin, range: NSRange(startIndex..., in: self))
+        let splits = [startIndex]
+            + matches
+                .map { Range($0.range, in: self)! }
+                .flatMap { [ $0.lowerBound, $0.upperBound ] }
+            + [endIndex]
+
+        return zip(splits, splits.dropFirst())
+            .map { String(self[$0 ..< $1]) }
+    }
+}
 
 // Custom Modifiers
 struct BuchTeilTitelKapitelAbschnitt: ViewModifier {


### PR DESCRIPTION
In manchen Fällen gab es einen Crash in der Regex-Funktion in `HighlightText`. Habe den body Komplet ersetzt.

Viel Swift-sugar, daher ist der Code vielleicht nicht so leicht zu verstehen. Im wesentlichen macht der neue Code genau das selbe, einfach sicherer.